### PR TITLE
Add support for plain Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Antivax (pun intended)
 
-A MutatingWebhook that will avoid Linkerd injection on your CronJobs
+A MutatingWebhook that will avoid Linkerd injection on your CronJobs and Jobs.
 
 ## Dependencies
 
@@ -13,3 +13,61 @@ A MutatingWebhook that will avoid Linkerd injection on your CronJobs
 
 2. Add the `antivax: enabled` label to the namespaces you want to avoid
 Linkerd injection.
+
+## What if I want to allow injection in only one Cronjob/Job?
+
+Then you'll need to manually add the annotation to that resource:
+
+1. CronJob example:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: testcronjob
+  namespace: antivax
+spec:
+  schedule: "* * * * *" #	Run every minute
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            linkerd.io/inject: enabled
+        spec:
+          containers:
+            - name: testcronjob
+              image: busybox:latest
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - date; echo Hello!
+          restartPolicy: OnFailure
+```
+
+2. Job example:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: testjob
+  namespace: antivax
+spec:
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: enabled
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: testjob
+          image: busybox:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - date; echo Hello!
+      restartPolicy: OnFailure
+```

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -92,17 +92,34 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: antivax/antivax-tls
 webhooks:
-  - name: antivax.default.svc.cluster.local
+  - name: antivax-cronjob.antivax.svc.cluster.local
     clientConfig:
       service:
         name: antivax
         namespace: antivax
-        path: "/mutate"
+        path: "/mutate-cronjob"
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: ["batch"]
         apiVersions: ["v1"]
         resources: ["cronjobs"]
+    namespaceSelector:
+      matchLabels:
+        antivax: enabled
+    admissionReviewVersions:
+      - v1
+    sideEffects: None
+  - name: antivax-job.antivax.svc.cluster.local
+    clientConfig:
+      service:
+        name: antivax
+        namespace: antivax
+        path: "/mutate-job"
+    rules:
+      - operations: [ "CREATE", "UPDATE" ]
+        apiGroups: [ "batch" ]
+        apiVersions: [ "v1" ]
+        resources: [ "jobs" ]
     namespaceSelector:
       matchLabels:
         antivax: enabled

--- a/mutate.go
+++ b/mutate.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	admission "k8s.io/api/admission/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
-func Mutate(body []byte) ([]byte, error) {
+const LinkerdInjectAnnotation = "linkerd.io/inject"
+
+func MutateCronjobs(body []byte) ([]byte, error) {
 	admReview := admission.AdmissionReview{}
 	if err := json.Unmarshal(body, &admReview); err != nil {
 		return nil, fmt.Errorf("unmarshaling request failed with %s", err)
@@ -25,22 +28,84 @@ func Mutate(body []byte) ([]byte, error) {
 		if err := json.Unmarshal(ar.Object.Raw, &cronjob); err != nil {
 			return nil, fmt.Errorf("unable unmarshal cronjob json object %v", err)
 		}
+
 		resp.Allowed = true
 		resp.UID = ar.UID
 		pT := admission.PatchTypeJSONPatch
 		resp.PatchType = &pT
 
-		op := map[string]interface{}{}
-		if _, present := cronjob.Spec.JobTemplate.Annotations["linkerd.io/inject"]; !present {
+		var op map[string]interface{}
+		if _, present := cronjob.Spec.JobTemplate.Spec.Template.Annotations[LinkerdInjectAnnotation]; !present {
+			log.WithField("cronjob", cronjob.Name).WithField("namespace", cronjob.Namespace).Info("Patch Cronjob")
 			op = map[string]interface{}{
 				"op":    "add",
 				"path":  "/spec/jobTemplate/spec/template/metadata/annotations",
-				"value": map[string]string{"linkerd.io/inject": "disabled"},
+				"value": map[string]string{LinkerdInjectAnnotation: "disabled"},
+			}
+			resp.Patch, err = json.Marshal([]interface{}{op})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			resp.Patch, err = json.Marshal([]interface{}{})
+			if err != nil {
+				return nil, err
 			}
 		}
-		resp.Patch, err = json.Marshal([]interface{}{op})
+
+		resp.Result = &metav1.Status{
+			Status: "Success",
+		}
+
+		admReview.Response = &resp
+		responseBody, err = json.Marshal(admReview)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	return responseBody, nil
+}
+
+func MutateJobs(body []byte) ([]byte, error) {
+	admReview := admission.AdmissionReview{}
+	if err := json.Unmarshal(body, &admReview); err != nil {
+		return nil, fmt.Errorf("unmarshaling request failed with %s", err)
+	}
+
+	var err error
+	var job *batchv1.Job
+
+	var responseBody []byte
+	ar := admReview.Request
+	resp := admission.AdmissionResponse{}
+
+	if ar != nil {
+		if err := json.Unmarshal(ar.Object.Raw, &job); err != nil {
+			return nil, fmt.Errorf("unable unmarshal job json object %v", err)
+		}
+		resp.Allowed = true
+		resp.UID = ar.UID
+		pT := admission.PatchTypeJSONPatch
+		resp.PatchType = &pT
+
+		var op map[string]interface{}
+		if _, present := job.Spec.Template.Annotations[LinkerdInjectAnnotation]; !present {
+			log.WithField("job", job.Name).WithField("namespace", job.Namespace).Info("Patch Job")
+			op = map[string]interface{}{
+				"op":    "add",
+				"path":  "/spec/template/metadata/annotations",
+				"value": map[string]string{LinkerdInjectAnnotation: "disabled"},
+			}
+			resp.Patch, err = json.Marshal([]interface{}{op})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			resp.Patch, err = json.Marshal([]interface{}{})
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		resp.Result = &metav1.Status{

--- a/testcronjob.yaml
+++ b/testcronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: testcronjob
+  namespace: antivax
+spec:
+  schedule: "* * * * *" #	Run every minute
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: testcronjob
+              image: busybox:latest
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - date; echo Hello!
+          restartPolicy: OnFailure

--- a/testdata/injectable_job.json
+++ b/testdata/injectable_job.json
@@ -1,0 +1,140 @@
+{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1",
+  "request": {
+    "uid": "a256a03b-84e5-423e-93ca-e173bb466913",
+    "kind": {
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
+    },
+    "resource": {
+      "group": "batch",
+      "version": "v1",
+      "resource": "jobs"
+    },
+    "requestKind": {
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
+    },
+    "requestResource": {
+      "group": "batch",
+      "version": "v1",
+      "resource": "jobs"
+    },
+    "name": "testjob",
+    "namespace": "antivax",
+    "operation": "CREATE",
+    "userInfo": {
+      "username": "jorge.diaz",
+      "uid": "jorge.diaz",
+      "groups": [
+        "admin",
+        "system:authenticated"
+      ]
+    },
+    "object": {
+      "kind": "Job",
+      "apiVersion": "batch/v1",
+      "metadata": {
+        "name": "testjob",
+        "namespace": "antivax",
+        "creationTimestamp": null,
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"annotations\":{},\"name\":\"testjob\",\"namespace\":\"antivax\"},\"spec\":{\"template\":{\"spec\":{\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"/bin/sh\",\"-c\",\"date; echo Hello!\"],\"image\":\"busybox:latest\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"testjob\"}],\"restartPolicy\":\"OnFailure\"}}}}\n"
+        },
+        "managedFields": [
+          {
+            "manager": "kubectl-client-side-apply",
+            "operation": "Update",
+            "apiVersion": "batch/v1",
+            "time": "2024-05-24T11:07:09Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                }
+              },
+              "f:spec": {
+                "f:backoffLimit": {},
+                "f:completionMode": {},
+                "f:completions": {},
+                "f:parallelism": {},
+                "f:suspend": {},
+                "f:template": {
+                  "f:spec": {
+                    "f:automountServiceAccountToken": {},
+                    "f:containers": {
+                      "k:{\"name\":\"testjob\"}": {
+                        ".": {},
+                        "f:command": {},
+                        "f:image": {},
+                        "f:imagePullPolicy": {},
+                        "f:name": {},
+                        "f:resources": {},
+                        "f:terminationMessagePath": {},
+                        "f:terminationMessagePolicy": {}
+                      }
+                    },
+                    "f:dnsPolicy": {},
+                    "f:restartPolicy": {},
+                    "f:schedulerName": {},
+                    "f:securityContext": {},
+                    "f:terminationGracePeriodSeconds": {}
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "spec": {
+        "parallelism": 1,
+        "completions": 1,
+        "backoffLimit": 6,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "testjob",
+                "image": "busybox:latest",
+                "command": [
+                  "/bin/sh",
+                  "-c",
+                  "date; echo Hello!"
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "OnFailure",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "automountServiceAccountToken": false,
+            "securityContext": {},
+            "schedulerName": "default-scheduler"
+          }
+        },
+        "completionMode": "NonIndexed",
+        "suspend": false
+      },
+      "status": {}
+    },
+    "oldObject": null,
+    "dryRun": false,
+    "options": {
+      "kind": "CreateOptions",
+      "apiVersion": "meta.k8s.io/v1",
+      "fieldManager": "kubectl-client-side-apply",
+      "fieldValidation": "Strict"
+    }
+  }
+}

--- a/testdata/non_injectable_cronjob.json
+++ b/testdata/non_injectable_cronjob.json
@@ -2,7 +2,7 @@
   "kind": "AdmissionReview",
   "apiVersion": "admission.k8s.io/v1",
   "request": {
-    "uid": "34dc2238-8365-4dab-8807-7685596da8a5",
+    "uid": "be9af218-aab6-4bab-a007-e1f27d7ed183",
     "kind": {
       "group": "batch",
       "version": "v1",
@@ -23,7 +23,7 @@
       "version": "v1",
       "resource": "cronjobs"
     },
-    "name": "testjob",
+    "name": "testcronjob",
     "namespace": "antivax",
     "operation": "CREATE",
     "userInfo": {
@@ -38,18 +38,18 @@
       "kind": "CronJob",
       "apiVersion": "batch/v1",
       "metadata": {
-        "name": "testjob",
+        "name": "testcronjob",
         "namespace": "antivax",
         "creationTimestamp": null,
         "annotations": {
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"CronJob\",\"metadata\":{\"annotations\":{},\"name\":\"testjob\",\"namespace\":\"antivax\"},\"spec\":{\"jobTemplate\":{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"command\":[\"/bin/sh\",\"-c\",\"date; echo Hello!\"],\"image\":\"busybox:latest\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"testjob\"}],\"restartPolicy\":\"OnFailure\"}}}},\"schedule\":\"* * * * *\"}}\n"
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"CronJob\",\"metadata\":{\"annotations\":{},\"name\":\"testcronjob\",\"namespace\":\"antivax\"},\"spec\":{\"jobTemplate\":{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"linkerd.io/inject\":\"enabled\"}},\"spec\":{\"containers\":[{\"command\":[\"/bin/sh\",\"-c\",\"date; echo Hello!\"],\"image\":\"busybox:latest\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"testcronjob\"}],\"restartPolicy\":\"OnFailure\"}}}},\"schedule\":\"* * * * *\"}}\n"
         },
         "managedFields": [
           {
             "manager": "kubectl-client-side-apply",
             "operation": "Update",
             "apiVersion": "batch/v1",
-            "time": "2024-02-09T12:24:24Z",
+            "time": "2024-05-24T12:09:53Z",
             "fieldsType": "FieldsV1",
             "fieldsV1": {
               "f:metadata": {
@@ -64,9 +64,15 @@
                 "f:jobTemplate": {
                   "f:spec": {
                     "f:template": {
+                      "f:metadata": {
+                        "f:annotations": {
+                          ".": {},
+                          "f:linkerd.io/inject": {}
+                        }
+                      },
                       "f:spec": {
                         "f:containers": {
-                          "k:{\"name\":\"testjob\"}": {
+                          "k:{\"name\":\"testcronjob\"}": {
                             ".": {},
                             "f:command": {},
                             "f:image": {},
@@ -100,20 +106,20 @@
         "suspend": false,
         "jobTemplate": {
           "metadata": {
-            "creationTimestamp": null,
-            "annotations": {
-              "linkerd.io/inject": "enabled"
-            }
+            "creationTimestamp": null
           },
           "spec": {
             "template": {
               "metadata": {
-                "creationTimestamp": null
+                "creationTimestamp": null,
+                "annotations": {
+                  "linkerd.io/inject": "enabled"
+                }
               },
               "spec": {
                 "containers": [
                   {
-                    "name": "testjob",
+                    "name": "testcronjob",
                     "image": "busybox:latest",
                     "command": [
                       "/bin/sh",

--- a/testdata/non_injectable_job.json
+++ b/testdata/non_injectable_job.json
@@ -1,0 +1,149 @@
+{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1",
+  "request": {
+    "uid": "ad69db33-a235-435f-b003-40ae1a91a3ca",
+    "kind": {
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
+    },
+    "resource": {
+      "group": "batch",
+      "version": "v1",
+      "resource": "jobs"
+    },
+    "requestKind": {
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
+    },
+    "requestResource": {
+      "group": "batch",
+      "version": "v1",
+      "resource": "jobs"
+    },
+    "name": "testjob",
+    "namespace": "antivax",
+    "operation": "CREATE",
+    "userInfo": {
+      "username": "jorge.diaz",
+      "uid": "jorge.diaz",
+      "groups": [
+        "admin",
+        "system:authenticated"
+      ]
+    },
+    "object": {
+      "kind": "Job",
+      "apiVersion": "batch/v1",
+      "metadata": {
+        "name": "testjob",
+        "namespace": "antivax",
+        "creationTimestamp": null,
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"metadata\":{\"annotations\":{},\"name\":\"testjob\",\"namespace\":\"antivax\"},\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"linkerd.io/inject\":\"enabled\"}},\"spec\":{\"automountServiceAccountToken\":false,\"containers\":[{\"command\":[\"/bin/sh\",\"-c\",\"date; echo Hello!\"],\"image\":\"busybox:latest\",\"imagePullPolicy\":\"IfNotPresent\",\"name\":\"testjob\"}],\"restartPolicy\":\"OnFailure\"}}}}\n"
+        },
+        "managedFields": [
+          {
+            "manager": "kubectl-client-side-apply",
+            "operation": "Update",
+            "apiVersion": "batch/v1",
+            "time": "2024-05-24T11:14:53Z",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                }
+              },
+              "f:spec": {
+                "f:backoffLimit": {},
+                "f:completionMode": {},
+                "f:completions": {},
+                "f:parallelism": {},
+                "f:suspend": {},
+                "f:template": {
+                  "f:metadata": {
+                    "f:annotations": {
+                      ".": {},
+                      "f:linkerd.io/inject": {}
+                    }
+                  },
+                  "f:spec": {
+                    "f:automountServiceAccountToken": {},
+                    "f:containers": {
+                      "k:{\"name\":\"testjob\"}": {
+                        ".": {},
+                        "f:command": {},
+                        "f:image": {},
+                        "f:imagePullPolicy": {},
+                        "f:name": {},
+                        "f:resources": {},
+                        "f:terminationMessagePath": {},
+                        "f:terminationMessagePolicy": {}
+                      }
+                    },
+                    "f:dnsPolicy": {},
+                    "f:restartPolicy": {},
+                    "f:schedulerName": {},
+                    "f:securityContext": {},
+                    "f:terminationGracePeriodSeconds": {}
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "spec": {
+        "parallelism": 1,
+        "completions": 1,
+        "backoffLimit": 6,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "annotations": {
+              "linkerd.io/inject": "enabled"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "testjob",
+                "image": "busybox:latest",
+                "command": [
+                  "/bin/sh",
+                  "-c",
+                  "date; echo Hello!"
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "OnFailure",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "automountServiceAccountToken": false,
+            "securityContext": {},
+            "schedulerName": "default-scheduler"
+          }
+        },
+        "completionMode": "NonIndexed",
+        "suspend": false
+      },
+      "status": {}
+    },
+    "oldObject": null,
+    "dryRun": false,
+    "options": {
+      "kind": "CreateOptions",
+      "apiVersion": "meta.k8s.io/v1",
+      "fieldManager": "kubectl-client-side-apply",
+      "fieldValidation": "Strict"
+    }
+  }
+}

--- a/testjob.yaml
+++ b/testjob.yaml
@@ -1,20 +1,18 @@
 apiVersion: batch/v1
-kind: CronJob
+kind: Job
 metadata:
   name: testjob
   namespace: antivax
 spec:
-  schedule: "* * * * *" #	Run every minute
-  jobTemplate:
+  template:
     spec:
-      template:
-        spec:
-          containers:
-            - name: testjob
-              image: busybox:latest
-              imagePullPolicy: IfNotPresent
-              command:
-                - /bin/sh
-                - -c
-                - date; echo Hello!
-          restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      containers:
+        - name: testjob
+          image: busybox:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - date; echo Hello!
+      restartPolicy: OnFailure


### PR DESCRIPTION
So far we have only supported CronJobs.
This also fixes a bug in the previous version that was not taking into account the correct annotation CronJobs and introduces a flag (verbose) to enable debug logs.