### PR TITLE
chore: update Go version to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine AS build
+FROM golang:1.26.3-alpine AS build
 
 RUN adduser --uid 10000 --disabled-password antivax
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module antivax
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/sirupsen/logrus v1.9.4


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.3**.

### Changes
- go.mod: go 1.26.2 → go 1.26.3
- Dockerfile: golang:1.26.2 → golang:1.26.3

_Automated PR by update-go-version.sh_